### PR TITLE
Renamed "streaming collector" to "streaming-collector"

### DIFF
--- a/control/plugin/plugin.go
+++ b/control/plugin/plugin.go
@@ -91,7 +91,7 @@ var (
 		"collector",
 		"processor",
 		"publisher",
-		"streaming collector",
+		"streaming-collector",
 	}
 
 	routingStrategyTypes = [...]string{

--- a/core/plugin.go
+++ b/core/plugin.go
@@ -52,7 +52,7 @@ func ToPluginType(name string) (PluginType, error) {
 		"collector":           0,
 		"processor":           1,
 		"publisher":           2,
-		"streaming collector": 3,
+		"streaming-collector": 3,
 	}
 	t, ok := pts[name]
 	if !ok {
@@ -66,7 +66,7 @@ func CheckPluginType(id PluginType) bool {
 		0: "collector",
 		1: "processor",
 		2: "publisher",
-		3: "streaming collector",
+		3: "streaming-collector",
 	}
 
 	_, ok := pts[id]
@@ -89,7 +89,7 @@ func (pt PluginType) String() string {
 		"collector",
 		"processor",
 		"publisher",
-		"streaming collector",
+		"streaming-collector",
 	}[pt]
 }
 


### PR DESCRIPTION
Summary of changes:
- renamed "streaming collector" to "streaming-collector"

The proposed change simplify unloading streaming collector plugin.

Before:
```snaptel plugin unload  "streaming collector" test-rand-streamer 1```

After:
```snaptel plugin unload  streaming-collector test-rand-streamer 1```


Testing done:
- loading streaming collector plugin and the unloading it by without need of escaping space

cc: @jcooklin 
